### PR TITLE
Support for Elixir 1.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ notifications:
     - jerp@checkiz.com
 elixir:
   - 1.0.2
-  - 1.1.1
+  - 1.2.0
 otp_release:
   - 17.4
-  - 18.1
+  - 18.2
 sudo: false

--- a/lib/bson_decoder.ex
+++ b/lib/bson_decoder.ex
@@ -51,7 +51,7 @@ defmodule Bson.Decoder do
 
   ```
   """
-  def elist_to_hashdict(elist), do: elist |> Enum.reduce %HashDict{}, fn({k, v}, h) -> HashDict.put(h, k, v) end
+  def elist_to_hashdict(elist), do: elist |> Enum.reduce(%HashDict{}, fn({k, v}, h) -> HashDict.put(h, k, v) end)
 
   @doc """
   Transform an elist to a Keyword
@@ -62,7 +62,7 @@ defmodule Bson.Decoder do
 
   ```
   """
-  def elist_to_keyword(elist), do: elist |> Enum.map fn({k, v}) -> {String.to_atom(k), v} end
+  def elist_to_keyword(elist), do: elist |> Enum.map(fn({k, v}) -> {String.to_atom(k), v} end)
 
   @doc """
   Identity function
@@ -91,7 +91,7 @@ defmodule Bson.Decoder do
   ...>  %{a: "r"},
   ...>  %{a: ""},
   ...>  %{a: 1, b: 5}
-  ...> ] |> Enum.all? fn(term) -> assert term == term |> Bson.encode |> Bson.decode end
+  ...> ] |> Enum.all?(fn(term) -> assert term == term |> Bson.encode |> Bson.decode end)
   true
 
   iex> term = %{

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule Bson.Mixfile do
     [ app: :bson,
       name: "bson",
       version: "0.4.4",
-      elixir: "~> 1.0 or ~> 1.1",
+      elixir: "~> 1.0 or ~> 1.1 or ~> 1.2",
       description: "BSON implementation for Elixir",
       source_url: "https://github.com/checkiz/elixir-bson",
       deps: deps(Mix.env),


### PR DESCRIPTION
Just as with 1.1, bump Elixir version requirement, update travis config, and some minor tweaks to avoid new 1.2 warnings.